### PR TITLE
#7 Remove GitHub Packages references from code-quality workflow

### DIFF
--- a/.github/workflows/code-quality-pnpm.yaml
+++ b/.github/workflows/code-quality-pnpm.yaml
@@ -22,10 +22,6 @@ on:
       pnpm-version:
         type: string
         default: '10.12.4'
-    secrets:
-      # Allows a consumer to add this token to the environment, typically for use in `.npmrc`
-      GH_PACKAGES_TOKEN:
-        required: false
 
 jobs:
   code-quality:
@@ -38,7 +34,6 @@ jobs:
       cancel-in-progress: true
 
     env:
-      GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:


### PR DESCRIPTION
Closes #7 

## What

Remove the `GH_PACKAGES_TOKEN` secret declaration and env var from the reusable `code-quality-pnpm.yaml` workflow. All packages have moved to npmjs.org, so GitHub Packages auth is no longer needed.

## Why

The GitHub Packages registry references are vestigial — all packages now resolve from npmjs.org. Keeping the `GH_PACKAGES_TOKEN` pattern encourages downstream repos to copy it into their own workflows, leading to 404 errors when packages aren't found on GitHub Packages.

## Details

### CI

- Remove `secrets.GH_PACKAGES_TOKEN` input (was already `required: false`)
- Remove `GH_PACKAGES_TOKEN` env var from the `code-quality` job
- Retain `GITHUB_TOKEN` env var (auto-provided, may be used by downstream `pnpm run ci` scripts)

## Test plan

- Caller repos that pass `GH_PACKAGES_TOKEN` continue to work (extra secret is silently ignored)
- Caller repos that omit `GH_PACKAGES_TOKEN` install dependencies from npmjs.org without error