### PR TITLE
#11 Replace pnpm/action-setup with corepack enable

### DIFF
--- a/.github/workflows/code-quality-pnpm-workflow.yaml
+++ b/.github/workflows/code-quality-pnpm-workflow.yaml
@@ -14,9 +14,6 @@ on:
       node-version:
         type: string
         default: '24.14.1'
-      pnpm-version:
-        type: string
-        default: '10.33.0'
 
 jobs:
   code-quality:
@@ -35,11 +32,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: ${{ inputs.pnpm-version }}
-          run_install: false
+      # pnpm version is governed by each consumer's `packageManager` field in package.json.
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Set up Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## What

Replace the `pnpm/action-setup` third-party action with Node.js's built-in corepack in the `code-quality-pnpm-workflow.yaml` reusable workflow. Remove the `pnpm-version` input — pnpm version is now governed by each consuming project's `packageManager` field in `package.json`.

## Why

Corepack is the standard Node.js mechanism for managing package manager versions. Using it eliminates a third-party action dependency and decentralizes version control to each consuming repository, where it belongs.

## Details

### Features

- Replace the "Install pnpm" step (`pnpm/action-setup@v5`) with a "Enable corepack" step (`corepack enable`).
- Remove the `pnpm-version` workflow input (breaking change for consumers passing this input).
- Add a comment noting that pnpm version is governed by the consumer's `packageManager` field.

## Test plan

- [ ] Verify workflow runs successfully on a consuming repo that declares `packageManager` in `package.json`.
- [ ] Verify `setup-node` pnpm cache still works with corepack-provided pnpm shim.

Closes #11