### PR TITLE
#13 Add setup-command input to code-quality workflow

### DIFF
--- a/.changeset/add-setup-command-input.md
+++ b/.changeset/add-setup-command-input.md
@@ -1,0 +1,5 @@
+---
+'templates.github': minor
+---
+
+Add optional `setup-command` input to `code-quality-pnpm-workflow.yaml`. Consumers can pass a shell command (e.g., `sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep`) that runs before the check command, eliminating the need to mix install steps into `check-command`. The consumer is responsible for `sudo`, package-manager flags, and any necessary index updates.

--- a/.github/schemas/code-quality-pnpm-workflow.json
+++ b/.github/schemas/code-quality-pnpm-workflow.json
@@ -25,6 +25,10 @@
                     "node-version": {
                       "type": "string",
                       "description": "Optional. Node.js version. Uses the workflow's default if not provided."
+                    },
+                    "setup-command": {
+                      "type": "string",
+                      "description": "Optional. Shell command to run after dependency installation and bootstrap, before the check command. Use for installing system dependencies. The consumer is responsible for sudo, package-manager flags, and any necessary index updates (e.g., apt-get update)."
                     }
                   },
                   "required": ["check-command"],

--- a/.github/workflows/code-quality-pnpm-workflow.yaml
+++ b/.github/workflows/code-quality-pnpm-workflow.yaml
@@ -14,6 +14,14 @@ on:
       node-version:
         type: string
         default: '24.14.1'
+      setup-command:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional shell command to run after dependency installation and bootstrap, before the check command.
+          Use for installing system dependencies. The consumer is responsible for sudo, package-manager flags,
+          and any necessary index updates (e.g., apt-get update).
 
 jobs:
   code-quality:
@@ -47,6 +55,12 @@ jobs:
 
       - name: Bootstrap
         run: pnpm run --if-present bootstrap
+
+      - name: Run setup command
+        if: inputs.setup-command != ''
+        env:
+          SETUP_COMMAND: ${{ inputs.setup-command }}
+        run: bash -eo pipefail -c "$SETUP_COMMAND"
 
       - name: Run code quality & build checks
         run: ${{ inputs.check-command }}

--- a/.github/workflows/code-quality-pnpm.test.yaml
+++ b/.github/workflows/code-quality-pnpm.test.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Test code-quality-pnpm-workflow
+
+# Self-test for the reusable code-quality workflow.
+# Verifies that the setup-command input installs a tool that the check-command then uses.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/code-quality-pnpm-workflow.yaml'
+      - '.github/workflows/code-quality-pnpm.test.yaml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/code-quality-pnpm-workflow.yaml'
+      - '.github/workflows/code-quality-pnpm.test.yaml'
+  workflow_dispatch:
+
+jobs:
+  setup-command-installs-ripgrep:
+    name: setup-command installs ripgrep
+    uses: ./.github/workflows/code-quality-pnpm-workflow.yaml
+    with:
+      setup-command: 'sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep'
+      check-command: 'rg --version'
+
+  default-path-no-setup-command:
+    name: default path (no setup-command) succeeds
+    uses: ./.github/workflows/code-quality-pnpm-workflow.yaml
+    with:
+      check-command: 'true'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,53 @@
 # .github
 
 Organization-wide workflows and default templates.
+
+## Reusable workflows
+
+### `code-quality-pnpm-workflow.yaml`
+
+Runs code quality and build checks for pnpm-based projects on `ubuntu-latest`.
+
+#### Inputs
+
+| Name            | Type     | Required | Default   | Description                                                                                                                                                                                                                                                       |
+| --------------- | -------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `check-command` | `string` | yes      | —         | Command to run code quality and build checks (e.g., `pnpm run ci`, `nmr ci`).                                                                                                                                                                                     |
+| `node-version`  | `string` | no       | `24.14.1` | Node.js version.                                                                                                                                                                                                                                                  |
+| `setup-command` | `string` | no       | `''`      | Optional shell command to run after dependency installation and bootstrap, before the check command. Use for installing system dependencies. The consumer is responsible for sudo, package-manager flags, and any necessary index updates (e.g., apt-get update). |
+
+#### Usage
+
+Minimal caller:
+
+```yaml
+jobs:
+  code-quality:
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v5
+    with:
+      check-command: 'pnpm run ci'
+```
+
+Install an apt package before running checks (e.g., `ripgrep`):
+
+```yaml
+jobs:
+  code-quality:
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v5
+    with:
+      check-command: 'pnpm run ci'
+      setup-command: 'sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep'
+```
+
+Install a tool via vendor script (e.g., `shellspec`):
+
+```yaml
+jobs:
+  code-quality:
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v5
+    with:
+      check-command: 'pnpm run ci'
+      setup-command: 'curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes'
+```
+
+The `setup-command` runs after dependencies are installed and the optional `bootstrap` script, and before `check-command`. The workflow does not run `apt-get update` or supply `sudo` on the consumer's behalf — include those in the command when needed.


### PR DESCRIPTION
## What

Adds an optional `setup-command` input to the reusable code-quality workflow, letting callers run a shell command after install and bootstrap and before the check step. A typical use is to install system dependencies needed by the check step.

## Why

Consumers whose tests need a binary that isn't preinstalled on `ubuntu-latest` (e.g., `ripgrep`, `shellspec`) previously had no clean way to install it. The only recourse was to mix install commands into `check-command`, conflating "install dependencies" and "run checks" into one shell string — or to skip those tests in CI entirely. Two known use cases (`ripgrep` from apt, `shellspec` from a vendor script) span two install mechanisms, so the input is a single generic shell command rather than an apt-specific shape.

## Details

### 🎉 Features

- Reusable workflow accepts an optional `setup-command` input. When non-empty, the command runs after dependency install and bootstrap, before the check command. Passed via `env:` and invoked as `bash -eo pipefail -c "$SETUP_COMMAND"` so the spawned subshell inherits the same fail-fast contract that the rest of the workflow's `run:` blocks operate under.
- Caller-workflow JSON schema (`code-quality-pnpm-workflow.json`) extended with `setup-command`; `additionalProperties: false` and `required: ["check-command"]` preserved.
- README rewritten with a full reusable-workflow reference: inputs table covering all three inputs, minimal-caller example, apt-install example (`ripgrep`), and vendor-script example (`shellspec`).

### 🧪 Tests

- New `code-quality-pnpm.test.yaml` self-test workflow with two jobs: one installs `ripgrep` via apt and asserts `rg --version` succeeds inside `check-command`; the other calls the reusable workflow with no `setup-command` to lock the default path against regression. Triggers are scoped via `paths:` to only the two workflow files involved.

Closes #13
