### PR TITLE
#15 Remove built-in concurrency from the code-quality workflow

### DIFF
--- a/.changeset/caller-owned-concurrency.md
+++ b/.changeset/caller-owned-concurrency.md
@@ -1,0 +1,7 @@
+---
+'templates.github': major
+---
+
+Remove the built-in job-level `concurrency` group from `code-quality-pnpm-workflow.yaml`. Concurrency is now the caller's responsibility, declared at the caller's workflow level.
+
+**Breaking:** consumers that relied on the workflow to auto-cancel superseded runs must add a workflow-level `concurrency` block to their caller (see the README's Concurrency section). In exchange, callers can now run the workflow across a matrix (e.g. multiple Node versions) with every leg running to completion — the job-level group previously shared across a caller's matrix legs, which silently cancelled all but one, is gone.

--- a/.github/workflows/code-quality-pnpm-workflow.yaml
+++ b/.github/workflows/code-quality-pnpm-workflow.yaml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    # Concurrency is intentionally caller-owned: declare it at the caller's workflow level
+    # (see README). A job-level group here is shared across a caller's matrix legs and
+    # cancels them — see issue #15.
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-quality-pnpm.test.yaml
+++ b/.github/workflows/code-quality-pnpm.test.yaml
@@ -2,7 +2,11 @@
 name: Test code-quality-pnpm-workflow
 
 # Self-test for the reusable code-quality workflow.
-# Verifies that the setup-command input installs a tool that the check-command then uses.
+# Verifies that the setup-command input installs a tool that the check-command then uses,
+# and that a caller-side Node-version matrix runs every leg to completion (see issue #15).
+#
+# Concurrency is declared here at the workflow level — the pattern consumers should follow
+# now that the reusable workflow no longer manages it.
 
 on:
   pull_request:
@@ -15,6 +19,10 @@ on:
       - '.github/workflows/code-quality-pnpm-workflow.yaml'
       - '.github/workflows/code-quality-pnpm.test.yaml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   setup-command-installs-ripgrep:
@@ -29,3 +37,13 @@ jobs:
     uses: ./.github/workflows/code-quality-pnpm-workflow.yaml
     with:
       check-command: 'true'
+
+  matrix-runs-all-legs:
+    name: matrix runs all legs (node ${{ matrix.node-version }})
+    strategy:
+      matrix:
+        node-version: ['22.13.0', '24.14.1']
+    uses: ./.github/workflows/code-quality-pnpm-workflow.yaml
+    with:
+      node-version: ${{ matrix.node-version }}
+      check-command: 'node --version'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Minimal caller:
 ```yaml
 jobs:
   code-quality:
-    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v5
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v6
     with:
       check-command: 'pnpm run ci'
 ```
@@ -33,7 +33,7 @@ Install an apt package before running checks (e.g., `ripgrep`):
 ```yaml
 jobs:
   code-quality:
-    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v5
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v6
     with:
       check-command: 'pnpm run ci'
       setup-command: 'sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep'
@@ -44,10 +44,48 @@ Install a tool via vendor script (e.g., `shellspec`):
 ```yaml
 jobs:
   code-quality:
-    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v5
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v6
     with:
       check-command: 'pnpm run ci'
       setup-command: 'curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes'
 ```
 
 The `setup-command` runs after dependencies are installed and the optional `bootstrap` script, and before `check-command`. The workflow does not run `apt-get update` or supply `sudo` on the consumer's behalf — include those in the command when needed.
+
+Run checks across a Node-version matrix:
+
+```yaml
+jobs:
+  code-quality:
+    strategy:
+      matrix:
+        node-version: ['22.13.0', '24.14.1']
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v6
+    with:
+      node-version: ${{ matrix.node-version }}
+      check-command: 'pnpm run ci'
+```
+
+Every leg runs to completion — the workflow declares no concurrency of its own, so matrix legs never cancel each other. Nothing beyond the matrix itself is required.
+
+#### Concurrency
+
+This workflow does not manage concurrency; that is the caller's responsibility. To cancel superseded runs (for example, when you push a new commit while checks from the previous one are still running), declare a **workflow-level** `concurrency` block in your caller — at the top of the workflow file, not inside the job that calls this workflow:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v6
+    with:
+      check-command: 'pnpm run ci'
+```
+
+Workflow-level concurrency cancels a superseded _run_ while leaving the current run's matrix legs intact, so it composes correctly with the matrix example above. A job-level group placed inside a matrixed caller would instead be shared across the legs and cancel them.
+
+#### Migrating from v5 to v6
+
+`v6` removes the built-in job-level `concurrency` group that earlier versions declared. If you relied on it to auto-cancel superseded runs, add the workflow-level `concurrency` block shown above to your caller. Callers that matrix over Node versions (or any other axis) no longer need a workaround — every leg now runs.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Run checks across a Node-version matrix:
 jobs:
   code-quality:
     strategy:
+      fail-fast: false
       matrix:
         node-version: ['22.13.0', '24.14.1']
     uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v6
@@ -66,7 +67,7 @@ jobs:
       check-command: 'pnpm run ci'
 ```
 
-Every leg runs to completion — the workflow declares no concurrency of its own, so matrix legs never cancel each other. Nothing beyond the matrix itself is required.
+The workflow declares no concurrency of its own, so the matrix fans out with nothing beyond the matrix itself required. `fail-fast: false` is recommended for a compatibility matrix: without it, the first leg to fail cancels the others, so you would see only one failing Node version instead of every affected one.
 
 #### Concurrency
 


### PR DESCRIPTION
## What

Consumers can now run the reusable code-quality workflow across a build matrix (multiple Node versions, for instance) with every leg running to completion; previously all but one matrix leg was silently cancelled. The workflow no longer manages concurrency of its own, so consumers who relied on it to auto-cancel superseded runs must add a workflow-level concurrency block to their own caller to restore that behavior. Shipped as a new major (`v6`); callers pinned to `v5` are unaffected until they upgrade.

## Why

Consumers could not run the reusable workflow across a build matrix: a built-in concurrency group collapsed every matrix leg but one, silently cancelling the rest, so a regression that broke on one axis value (say, a single Node version) while passing on another could ship undetected.

## Details

### 🪦 Removed

- 🚨 **Breaking:** The reusable `code-quality-pnpm-workflow.yaml` no longer declares a `concurrency` block; concurrency is now the caller's responsibility. Consumers that relied on the built-in group to auto-cancel superseded runs must add a workflow-level `concurrency` block to their caller. Shipped as `v6`; `v5` is not moved.

### 🧪 Tests

- The self-test workflow adds a job that calls the reusable workflow across a Node-version matrix (`22.13.0`, `24.14.1`) and asserts every leg completes, and declares a workflow-level `concurrency` block to model the recommended caller pattern.

### 📚 Documentation

- The README documents the caller-owned concurrency contract: a matrix usage example (recommending `fail-fast: false` for full per-axis visibility), a workflow-level `concurrency` pattern for restoring stale-run cancellation, and a v5-to-v6 migration note. Usage-example version pins are bumped to `@v6`.

Closes #15
