### PR TITLE
#23 Add a shellspec-version input to the code-quality workflow

### DIFF
--- a/.github/schemas/code-quality-pnpm-workflow.json
+++ b/.github/schemas/code-quality-pnpm-workflow.json
@@ -33,6 +33,10 @@
                     "setup-command": {
                       "type": "string",
                       "description": "Optional. Shell command to run after dependency installation and bootstrap, before the check command. Use for installing system dependencies. The consumer is responsible for sudo, package-manager flags, and any necessary index updates (e.g., apt-get update)."
+                    },
+                    "shellspec-version": {
+                      "type": "string",
+                      "description": "Optional. Shellspec release to install before the checks run (e.g. 0.28.1). Omit to install nothing. The installer comes from the named release's own tag."
                     }
                   },
                   "required": ["check-command"],

--- a/.github/workflows/code-quality-pnpm-workflow.yaml
+++ b/.github/workflows/code-quality-pnpm-workflow.yaml
@@ -33,6 +33,13 @@ on:
           Optional shell command to run after dependency installation and bootstrap, before the check command.
           Use for installing system dependencies. The consumer is responsible for sudo, package-manager flags,
           and any necessary index updates (e.g., apt-get update).
+      shellspec-version:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Shellspec release to install before the checks run (e.g. "0.28.1"). Leave unset to install
+          nothing. The installer comes from the named release's own tag.
 
 jobs:
   code-quality:
@@ -64,6 +71,23 @@ jobs:
           node-version: ${{ inputs.node-version }}
           node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}
           cache: 'pnpm'
+
+      # shellspec is not in apt. Fetching install.sh from the named release's own tag keeps the
+      # installer and the code it installs one reviewed snapshot, and leaves no shellspec version
+      # pinned here. The installer's default prefix is $HOME/.local, so no sudo is needed.
+      - name: Install shellspec
+        if: inputs.shellspec-version != ''
+        env:
+          SHELLSPEC_VERSION: ${{ inputs.shellspec-version }}
+        run: |
+          installer="$RUNNER_TEMP/shellspec-install.sh"
+          curl -fsSL -o "$installer" \
+            "https://raw.githubusercontent.com/shellspec/shellspec/$SHELLSPEC_VERSION/install.sh"
+          # --yes is required: the installer's confirm prompt reads /dev/tty, which a step has none of.
+          sh "$installer" "$SHELLSPEC_VERSION" --yes
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # $GITHUB_PATH takes effect in later steps, so verify through the absolute path.
+          "$HOME/.local/bin/shellspec" --version
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/code-quality-pnpm-workflow.yaml
+++ b/.github/workflows/code-quality-pnpm-workflow.yaml
@@ -81,7 +81,7 @@ jobs:
           SHELLSPEC_VERSION: ${{ inputs.shellspec-version }}
         run: |
           installer="$RUNNER_TEMP/shellspec-install.sh"
-          curl -fsSL -o "$installer" \
+          curl --fail --silent --show-error --location --retry 3 --output "$installer" \
             "https://raw.githubusercontent.com/shellspec/shellspec/$SHELLSPEC_VERSION/install.sh"
           # --yes is required: the installer's confirm prompt reads /dev/tty, which a step has none of.
           sh "$installer" "$SHELLSPEC_VERSION" --yes

--- a/.github/workflows/code-quality-pnpm.test.yaml
+++ b/.github/workflows/code-quality-pnpm.test.yaml
@@ -86,8 +86,9 @@ jobs:
       node-version-file: '.github/fixtures/.node-version'
       check-command: 'test "$(node --version)" = "v22.13.0"'
 
-  # A bare `shellspec` resolves only through the $GITHUB_PATH entry the install step writes,
-  # so this asserts the version and the PATH wiring together.
+  # Asserts the installed release is the requested one and that `shellspec` resolves for the check
+  # command. $HOME/.local/bin is on the hosted runner's default PATH, so this does not cover the
+  # install step's $GITHUB_PATH entry.
   shellspec-version-installs-requested-version:
     name: shellspec-version installs the requested version
     uses: ./.github/workflows/code-quality-pnpm-workflow.yaml

--- a/.github/workflows/code-quality-pnpm.test.yaml
+++ b/.github/workflows/code-quality-pnpm.test.yaml
@@ -4,11 +4,14 @@ name: Test code-quality-pnpm-workflow
 # Self-test for the reusable code-quality workflow.
 # Verifies that the setup-command input installs a tool that the check-command then uses,
 # that a caller-side Node-version matrix runs every leg to completion,
-# and that the Node version resolves from .tool-versions unless node-version overrides it or
-# node-version-file names another path.
+# that the Node version resolves from .tool-versions unless node-version overrides it or
+# node-version-file names another path,
+# and that shellspec-version installs shellspec for the check command only when it is set.
 #
 # The missing-.tool-versions failure path is deliberately uncovered: continue-on-error is not
 # supported on jobs that call a reusable workflow, so a call expected to fail cannot be asserted.
+# The same limitation leaves the clash between shellspec-version and a hand-rolled installer in
+# setup-command uncovered; the README's migration note carries it instead.
 #
 # Concurrency is declared here at the workflow level — the pattern consumers should follow
 # now that the reusable workflow no longer manages it.
@@ -82,3 +85,18 @@ jobs:
     with:
       node-version-file: '.github/fixtures/.node-version'
       check-command: 'test "$(node --version)" = "v22.13.0"'
+
+  # A bare `shellspec` resolves only through the $GITHUB_PATH entry the install step writes,
+  # so this asserts the version and the PATH wiring together.
+  shellspec-version-installs-requested-version:
+    name: shellspec-version installs the requested version
+    uses: ./.github/workflows/code-quality-pnpm-workflow.yaml
+    with:
+      shellspec-version: '0.28.1'
+      check-command: 'test "$(shellspec --version)" = "0.28.1"'
+
+  omitted-shellspec-version-installs-nothing:
+    name: omitted shellspec-version installs nothing
+    uses: ./.github/workflows/code-quality-pnpm-workflow.yaml
+    with:
+      check-command: '! command -v shellspec'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # .github
 
+Consumers pin the reusable workflows by major tag (`@v7`). A tag moves forward as non-breaking changes land, so a section grows after its tag is first cut; a breaking change opens the next tag instead.
+
+## v7
+
+### Features
+
+- Added a `shellspec-version` input to the `code-quality-pnpm` workflow, installing shellspec for the check command. Callers with a hand-rolled installer should see [Migrating from a hand-rolled shellspec install](README.md#migrating-from-a-hand-rolled-shellspec-install).
+- 🚨 Made the caller's `.tool-versions` the default Node version source; `node-version` remains as an override. See [Migrating from v6 to v7](README.md#migrating-from-v6-to-v7).
+
+### Removed
+
+- Removed the `sync-labels` workflow and its `labels.yaml` config.
+
+### Dependencies
+
+- Upgraded the pinned action versions and added dependabot to rotate them.
+
+## v6
+
+### Removed
+
+- 🚨 Removed the built-in job-level `concurrency` group; concurrency is the caller's to declare. See [Migrating from v5 to v6](README.md#migrating-from-v5-to-v6).
+
+## v5
+
+### Features
+
+- Added a `setup-command` input to the `code-quality-pnpm` workflow, for installing system dependencies before the checks run.
+- Added an optional `bootstrap` step, run after dependency installation.
+- Replaced `pnpm/action-setup` with corepack, so the pnpm version follows each consumer's `packageManager` field.
+
+---
+
+Releases below predate the tag-keyed scheme and were versioned as package semver, which nothing here publishes or consumes. The changesets that produced them were retired in `v7`.
+
 ## 1.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # .github
 
-Consumers pin the reusable workflows by major tag (`@v7`). A tag moves forward as non-breaking changes land, so a section grows after its tag is first cut; a breaking change opens the next tag instead.
+Consumers pin the reusable workflows by major tag (`@v7`). A tag moves forward as non-breaking changes land, so a section grows after its tag is first cut; a breaking change opens the next tag instead. Entries marked 🚨 break consumers moving to that tag.
 
 ## v7
 
@@ -11,7 +11,7 @@ Consumers pin the reusable workflows by major tag (`@v7`). A tag moves forward a
 
 ### Removed
 
-- Removed the `sync-labels` workflow and its `labels.yaml` config.
+- 🚨 Removed the `sync-labels` workflow and its `labels.yaml` config. It declared `on: workflow_call`, so a caller pinned to it has no replacement and must drop the job.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Runs code quality and build checks for pnpm-based projects on `ubuntu-latest`.
 | `node-version`      | `string` | no       | `''`             | Explicit Node.js version. Overrides `node-version-file`. Omit to use the version your repository already declares.                                                                                                                                                |
 | `node-version-file` | `string` | no       | `.tool-versions` | Path to a file declaring the Node.js version, relative to the repository root. Ignored when `node-version` is supplied.                                                                                                                                           |
 | `setup-command`     | `string` | no       | `''`             | Optional shell command to run after dependency installation and bootstrap, before the check command. Use for installing system dependencies. The consumer is responsible for sudo, package-manager flags, and any necessary index updates (e.g., apt-get update). |
+| `shellspec-version` | `string` | no       | `''`             | Shellspec release to install before the checks run (e.g., `0.28.1`). Omit to install nothing. The installer comes from the named release's own tag.                                                                                                               |
 
 #### Usage
 
@@ -42,7 +43,9 @@ jobs:
       setup-command: 'sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep'
 ```
 
-Install a tool via vendor script (e.g., `shellspec`):
+The `setup-command` runs after dependencies are installed and the optional `bootstrap` script, and before `check-command`. The workflow does not run `apt-get update` or supply `sudo` on the consumer's behalf — include those in the command when needed.
+
+Run shell tests (e.g., `shellspec`):
 
 ```yaml
 jobs:
@@ -50,10 +53,8 @@ jobs:
     uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v7
     with:
       check-command: 'pnpm run ci'
-      setup-command: 'curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes'
+      shellspec-version: '0.28.1'
 ```
-
-The `setup-command` runs after dependencies are installed and the optional `bootstrap` script, and before `check-command`. The workflow does not run `apt-get update` or supply `sudo` on the consumer's behalf — include those in the command when needed.
 
 Run checks across a Node-version matrix:
 
@@ -83,6 +84,14 @@ Three constraints on the file, each failing differently:
 - It must exist. A repository with neither a `node-version` input nor the file fails with `The specified node version file at: ... does not exist`. Add `.tool-versions`, or pass `node-version` explicitly.
 - It must declare a `nodejs` entry. A file present without one resolves to its own contents as the requested version, and the run fails with `Unable to find Node version '<contents>' for platform linux and architecture x64.` A polyglot `.tool-versions` kept for python or awscli alone lands here.
 - The `nodejs` entry must carry a single version and no trailing whitespace. `nodejs 24.18.0` resolves; `nodejs 24.18.0 22.13.0` does not, and fails the same way as a missing entry. Entries for other tools on their own lines are ignored, so a multi-tool `.tool-versions` is fine.
+
+#### Shell tests
+
+`shellspec` is not in Ubuntu's apt repositories, and it runs the shell tests rather than being a subject of them, so the workflow provisions it the way it provisions Node and pnpm. Set `shellspec-version` to the release you want and `shellspec` is on `PATH` for the check command; leave it unset and no installer is fetched at all.
+
+The input takes a concrete release, not a `latest` token. Every other version this workflow touches is pinned, and a floating one would let a shellspec release change your gate with no commit in either repository to explain it. Naming the release also fixes where the installer comes from: that release's own tag, so no moving branch reaches the shell.
+
+Tools the code under test consumes, such as `rg` or `jq`, are a different kind of dependency and stay in `setup-command`.
 
 #### Concurrency
 
@@ -125,3 +134,20 @@ jobs:
 Any test that guards against the two copies diverging (for example one built on `checkNodeVersionConsistency`) has nothing left to compare and can be deleted with it.
 
 Keep `node-version` only where you mean to override the file, such as a compatibility matrix. It still takes precedence when supplied, so a matrixed caller needs no change beyond the tag.
+
+#### Migrating from a hand-rolled shellspec install
+
+Before this input existed, callers installed shellspec themselves through `setup-command`. Delete that entry and set `shellspec-version` instead:
+
+```yaml
+jobs:
+  code-quality:
+    uses: williamthorsen/.github/.github/workflows/code-quality-pnpm-workflow.yaml@v7
+    with:
+      check-command: 'pnpm run ci'
+      shellspec-version: '0.28.1'
+```
+
+Delete it rather than leaving it alongside the input. The installer defaults to the same prefix this workflow installs into, and it aborts when its installation directory already exists, so a caller that sets both fails the run.
+
+The input is additive, so `v7` carries it without a tag bump.


### PR DESCRIPTION
## What

Adds an optional `shellspec-version` input to `code-quality-pnpm-workflow.yaml`. Specifying a release installs that release of shellspec before the checks run; omitting the input installs nothing. Consumers running shell tests no longer hand-roll a vendor-script invocation into `setup-command`.

Separately, rekeys `CHANGELOG.md` from an abandoned package-semver scheme to the major tags consumers pin, with sections for v5, v6, and v7. All three tags shipped without entries, including v7's removal of the `sync-labels` reusable workflow, which is now recorded as breaking.

## Why

Shell tests sit at the harness layer of the quality gate, alongside Node and pnpm, but the workflow provisioned no shellspec. Every consumer running shell tests had to install it themselves, and a consumer who forgot saw a green gate that had silently run no shell tests. `williamthorsen/codeassembly` ran that way for months; the gap surfaced only when an unrelated upgrade changed which command its check script runs, turning the absent binary into a hard failure.

The CHANGELOG recorded nothing a consumer could act on. Its only entry came from a versioning scheme nothing here publishes or consumes, while the tags consumers actually pin moved forward unrecorded, taking a removed reusable workflow with them.

## Details

### 🎉 Features

- The input is optional with an empty default, so a consumer that does not set it neither pays the install nor takes a dependency on an external fetch that can fail.
- The installer is fetched from the named release's own tag rather than a moving branch, so the installer and the code it installs are one snapshot and the workflow holds no shellspec version of its own. There is no `latest` token: an unbounded float would let a shellspec release change every consumer's gate with no commit in either repository to explain it.
- The install step sits between Node setup and dependency installation, so `shellspec` is on `PATH` for `bootstrap` and `setup-command` as well as for `check-command`. It installs under the runner user's home and needs no `sudo`.
- The installer fetch retries transient failures.
- `.github/schemas/code-quality-pnpm-workflow.json` gains the matching property, so a caller passing the input still validates under `additionalProperties: false`.

### 🧪 Tests

- Two self-test jobs in `code-quality-pnpm.test.yaml`: one installs a named release and asserts the version through a bare `shellspec` in the check command, the other omits the input and asserts `shellspec` is absent.
- The clash between the input and a hand-rolled installer left in `setup-command` stays deliberately uncovered. `continue-on-error` is unsupported on jobs that call a reusable workflow, so a call expected to fail cannot be asserted; the README's migration note carries it instead.

### 📚 Documentation

- `README.md` documents the input and drops the `master`-pinned vendor-script recipe it makes obsolete. A **Shell tests** section states where the boundary falls: shellspec runs the tests, so the workflow provisions it, while tools the code under test consumes, such as `rg` and `jq`, stay in `setup-command`.
- A migration section tells consumers moving off a hand-rolled install to delete the old `setup-command` entry rather than leave it alongside the input. The vendor installer aborts on a non-empty installation directory, so a caller that sets both fails the run.
- `CHANGELOG.md` is rekeyed to `## v7`, `## v6`, and `## v5`, with a preamble stating the tag scheme and the meaning of the 🚨 marker. The retired `1.2.0` entry stays below a note rather than being deleted.

Closes #23
